### PR TITLE
Drop flake8-isort, the functionality is replaced by isort pre-commit hook

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 -e .
 black==21.7b0
 flake8==3.9.2
-flake8-isort==4.0.0
 mypy==0.910
 pre-commit==2.13.0
 pytest==6.2.4


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos