### PR TITLE
ENG-275: support access tokens passed by WebSocket subprotocol

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,12 +28,12 @@ jobs:
     - name: Install python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9.9
+        python-version: 3.11
     - name: Cache packages
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-py-3.9.9-${{ hashFiles('requirements-dev.txt') }}-${{
+        key: ${{ runner.os }}-py-3.11-${{ hashFiles('requirements-dev.txt') }}-${{
           hashFiles('setup.py') }}
     - name: Install dependencies
       run: make setup
@@ -63,7 +63,7 @@ jobs:
     - name: Install python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.9.9
+        python-version: 3.11
     - name: Install dependencies
       run: |
         python -m pip install twine build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.3.0'
+  rev: 'v4.6.0'
   hooks:
   - id: check-merge-conflict
     exclude: "rst$"
 - repo: https://github.com/asottile/yesqa
-  rev: v1.3.0
+  rev: v1.5.0
   hooks:
   - id: yesqa
 - repo: https://github.com/sondrelg/pep585-upgrade
@@ -15,7 +15,7 @@ repos:
     args:
     - --futures=true
 - repo: https://github.com/Zac-HD/shed
-  rev: 0.10.1
+  rev: 2024.3.1
   hooks:
   - id: shed
     args:
@@ -26,11 +26,11 @@ repos:
     - markdown
     - rst
 - repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
+  rev: 7.1.1
   hooks:
   - id: flake8
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.3.0'
+  rev: 'v4.6.0'
   hooks:
   - id: check-case-conflict
   - id: check-json
@@ -44,14 +44,14 @@ repos:
   - id: debug-statements
 # Another entry is required to apply file-contents-sorter to another file
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 'v4.3.0'
+  rev: 'v4.6.0'
   hooks:
   - id: file-contents-sorter
     files: |
       docs/spelling_wordlist.txt|
       .gitignore
 - repo: https://github.com/rhysd/actionlint
-  rev: v1.6.15
+  rev: v1.7.1
   hooks:
   - id: actionlint-docker
     args:
@@ -62,7 +62,7 @@ repos:
     - -ignore
     - 'SC1004:'
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.17.1
+  rev: 0.29.1
   hooks:
   - id: check-github-actions
 ci:

--- a/neuro_auth_client/__init__.py
+++ b/neuro_auth_client/__init__.py
@@ -1,4 +1,5 @@
 """Neuromation auth client."""
+
 from importlib.metadata import version
 
 from .api import check_permissions

--- a/neuro_auth_client/api.py
+++ b/neuro_auth_client/api.py
@@ -8,6 +8,7 @@ from aiohttp_security import check_authorized
 from aiohttp_security.api import AUTZ_KEY
 
 from .client import Permission
+from .security import AuthPolicy
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,7 @@ async def check_permissions(
     auth_policy = request.config_dict.get(AUTZ_KEY)
     if not auth_policy:
         raise RuntimeError("Auth policy not configured")
+    assert isinstance(auth_policy, AuthPolicy)
 
     try:
         missing = await auth_policy.get_missing_permissions(user_name, permissions)

--- a/neuro_auth_client/client.py
+++ b/neuro_auth_client/client.py
@@ -151,7 +151,7 @@ class AuthClient:
         await self.close()
 
     def _generate_headers(self, token: Optional[str] = None) -> "CIMultiDict[str]":
-        headers: "CIMultiDict[str]" = CIMultiDict()
+        headers: CIMultiDict[str] = CIMultiDict()
         if token:
             headers[AUTHORIZATION] = BearerAuth(token).encode()
         return headers
@@ -342,9 +342,9 @@ class AuthClient:
         path = self._get_user_path(name) + "/token"
         headers = self._generate_headers(token)
         if new_token_uri:
-            data = dict(uri=new_token_uri)
+            data = {"uri": new_token_uri}
         else:
-            data = dict()
+            data = {}
         async with self._request("POST", path, headers=headers, json=data) as resp:
             payload = await resp.json()
             return payload["access_token"]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,8 +1,8 @@
 import pytest
-
-from neuro_auth_client.security import IdentityPolicy, AuthScheme
-from aiohttp.test_utils import make_mocked_request
 from aiohttp import BasicAuth
+from aiohttp.test_utils import make_mocked_request
+
+from neuro_auth_client.security import AuthScheme, IdentityPolicy
 
 
 async def test_identity_bearer() -> None:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,94 @@
+import pytest
+
+from neuro_auth_client.security import IdentityPolicy, AuthScheme
+from aiohttp.test_utils import make_mocked_request
+from aiohttp import BasicAuth
+
+
+async def test_identity_bearer() -> None:
+    req = make_mocked_request("GET", "/path", {"Authorization": "Bearer token1"})
+    ip = IdentityPolicy()
+    assert await ip.identify(req) == "token1"
+
+
+async def test_identity_query() -> None:
+    req = make_mocked_request("GET", "/path?neuro-auth-token=token2")
+    ip = IdentityPolicy()
+    assert await ip.identify(req) == "token2"
+
+
+async def test_identity_default() -> None:
+    req = make_mocked_request("GET", "/path")
+    ip = IdentityPolicy(default_identity="default")
+    assert await ip.identify(req) == "default"
+
+
+async def test_identity_basic() -> None:
+    auth = BasicAuth("user", "passwd")
+    req = make_mocked_request("GET", "/path", {"Authorization": auth.encode()})
+    ip = IdentityPolicy(AuthScheme.BASIC)
+    assert await ip.identify(req) == "passwd"
+
+
+async def test_identity_ws() -> None:
+    req = make_mocked_request(
+        "GET", "/path", {"Sec-WebSocket-Protocol": "bearer.apolo.us-token4"}
+    )
+    ip = IdentityPolicy()
+    assert await ip.identify(req) == "token4"
+
+
+async def test_identity_ws_multiple_subprotocols() -> None:
+    req = make_mocked_request(
+        "GET", "/path", {"Sec-WebSocket-Protocol": "chat bearer.apolo.us-token4 other"}
+    )
+    ip = IdentityPolicy()
+    assert await ip.identify(req) == "token4"
+
+
+@pytest.mark.parametrize(
+    "path,headers,token",
+    [
+        (  # all
+            "/path?neuro-auth-token=token1",
+            {
+                "Authorization": "Bearer token2",
+                "Sec-WebSocket-Protocol": "bearer.apolo.us-token3",
+            },
+            "token2",
+        ),
+        (  # header + query
+            "/path?neuro-auth-token=token1",
+            {
+                "Authorization": "Bearer token2",
+            },
+            "token2",
+        ),
+        (  # header + ws
+            "/path",
+            {
+                "Authorization": "Bearer token2",
+                "Sec-WebSocket-Protocol": "bearer.apolo.us-token3",
+            },
+            "token2",
+        ),
+        (  # query + ws
+            "/path?neuro-auth-token=token1",
+            {
+                "Sec-WebSocket-Protocol": "bearer.apolo.us-token3",
+            },
+            "token3",
+        ),
+        (  # default
+            "/path",
+            {},
+            "default",
+        ),
+    ],
+)
+async def test_identity_precedence(
+    path: str, headers: dict[str, str], token: str
+) -> None:
+    req = make_mocked_request("GET", path, headers)
+    ip = IdentityPolicy(default_identity="default")
+    assert await ip.identify(req) == token


### PR DESCRIPTION
Subprotocol for bearing token should have `bearer.apolo.us-<token>` form, the `token` is the same as passed to `Authorization` header in `Bearer` format (without 'bearer ' prefix).

Multiple protocols are supported, e.g., `chat bearer.apolo.us-<token>`; the bearer token is ignored on requested subprotocol negotiation.

After publishing the `neuro-auth-client` release, `platform-monitoring` should be upgraded to use the new feature.